### PR TITLE
Automatically strip newlines from Headers.

### DIFF
--- a/emailtools/cbe/__init__.py
+++ b/emailtools/cbe/__init__.py
@@ -6,9 +6,17 @@ from django.conf import settings
 from django.utils.html import strip_tags
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.safestring import mark_safe
+from django.utils.datastructures import SortedDict
 
 from .base import BaseEmail
 from .mixins import TemplateEmailMixin
+
+
+def stripnewlines(string):
+    """
+    Replaces all newlines with spaces.
+    """
+    return ' '.join(string.splitlines())
 
 
 class BasicEmail(BaseEmail):
@@ -30,14 +38,17 @@ class BasicEmail(BaseEmail):
     def get_email_message_kwargs(self, **kwargs):
         kwargs = super(BasicEmail, self).get_email_message_kwargs(**kwargs)
         kwargs.update({
-            'subject': self.get_subject(),
+            'subject': stripnewlines(self.get_subject()),
             'body': self.get_body(),
-            'from_email': self.get_from_email(),
+            'from_email': stripnewlines(self.get_from_email()),
             'to': self.get_to(),
             'cc': self.get_cc(),
             'bcc': self.get_bcc(),
             'connection': self.get_connection(),
-            'headers': self.get_headers(),
+            'headers': SortedDict((
+                (key, stripnewlines(value))
+                for key, value in self.get_headers().items()
+            ))
         })
         return kwargs
 

--- a/emailtools/cbe/__init__.py
+++ b/emailtools/cbe/__init__.py
@@ -37,6 +37,7 @@ class BasicEmail(BaseEmail):
             'cc': self.get_cc(),
             'bcc': self.get_bcc(),
             'connection': self.get_connection(),
+            'headers': self.get_headers(),
         })
         return kwargs
 

--- a/emailtools/tests.py
+++ b/emailtools/tests.py
@@ -125,6 +125,15 @@ class TestBasicCBE(TestCase):
         with self.assertRaises(TypeError):
             TestEmail('arst', 'tsra')
 
+    def test_extra_headers(self):
+        class TestEmail(self.TestEmail):
+            headers = {
+                'Test-Header': 'foo',
+            }
+
+        message = TestEmail().get_email_message().message()
+        self.assertEqual(message['Test-Header'], 'foo')
+
 
 class TestHTMLEmail(TestCase):
     EMAIL_ATTRS = {


### PR DESCRIPTION
This makes it easier to avoid unexpected BadHeaderErrors caused by
having multiline subject or from_email.

I understand that this feature may be a little controversial, because it is doing something not quite expected in the background, but I think that it is necessary if we are going to encourage this pattern:

``` python
class MyEmail(BasicEmail):
    def get_subject(self):
        return "{event} is coming up soon!".format(event=self.event.title)
```

Seeing as `event.title` is user input, it is possible that it contains newlines and would cause a 500.
