### PR TITLE
fix mutable function default argument

### DIFF
--- a/emailtools/cbe/__init__.py
+++ b/emailtools/cbe/__init__.py
@@ -124,5 +124,9 @@ class MarkdownEmail(HTMLEmail):
         md = super(MarkdownEmail, self).get_rendered_template()
         return loader.render_to_string(
             self.get_layout_template(),
-            self.get_layout_context_data(content=mark_safe(markdown.markdown(md, ['extra']))),
+            self.get_layout_context_data(
+                content=mark_safe(
+                    markdown.markdown(md, extensions=['markdown.extensions.extra']),
+                ),
+            ),
         )

--- a/emailtools/cbe/mixins.py
+++ b/emailtools/cbe/mixins.py
@@ -73,7 +73,9 @@ class UserTokenEmailMixin(BuildAbsoluteURIMixin):
     def get_uid(self, user):
         return int_to_base36(user.pk)
 
-    def reverse_token_url(self, view_name, args=None, kwargs={}):
+    def reverse_token_url(self, view_name, args=None, kwargs=None):
+        if kwargs is None:
+            kwargs = {}
         kwargs.setdefault(self.UID_KWARG, self.get_uid(self.get_user()))
         kwargs.setdefault(self.TOKEN_KWARG, self.generate_token(self.get_user()))
         return self.reverse_absolute_uri(view_name, args=args, kwargs=kwargs)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup, find_packages
 import subprocess
 import os
+import sys
 
 __doc__ = """
 App for Django featuring class based email sending
@@ -16,6 +17,9 @@ install_requires = [
     'Django>=1.3',
     'markdown',
 ]
+
+if sys.version.startswith("2.6"):
+    install_requires.append("importlib")
 
 STAGE = 'alpha'
 


### PR DESCRIPTION
One of the methods of `emailtools.cbe.mixins.UserTokenEmailMixin` had a mutable argument.  I removed it.

![42132895_scaled_372x480](https://cloud.githubusercontent.com/assets/824194/6386568/0335d7dc-bd38-11e4-98e0-d7a8cbb8ac7d.jpg)
