### PR TITLE
Use travis_retry instead of --use-mirrors since the latter is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ env:
   - DJANGO_PACKAGE=Django==1.4.5
   - DJANGO_PACKAGE=Django==1.5.1
 install:
-  - pip install -q $DJANGO_PACKAGE --use-mirrors
+  - travis_retry pip install -q $DJANGO_PACKAGE
   - python setup.py install
 script: make test


### PR DESCRIPTION
It will be removed at some point and I'm not sure that it does anything.

travis_retry repeats failed operations up to 3 times before giving up.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fusionbox/django-emailtools/8)

<!-- Reviewable:end -->
